### PR TITLE
feat(trino): Configure basic file-based access control in Trino

### DIFF
--- a/infra/ansible/roles/trino/files/trino/etc/access-control.properties
+++ b/infra/ansible/roles/trino/files/trino/etc/access-control.properties
@@ -1,1 +1,2 @@
-access-control.name=allow-all
+access-control.name=file
+security.config-file=/etc/trino/rules.json

--- a/infra/ansible/roles/trino/files/trino/etc/log.properties
+++ b/infra/ansible/roles/trino/files/trino/etc/log.properties
@@ -1,2 +1,2 @@
 # Enable verbose logging from Trino
-# io.trino=DEBUG
+#io.trino=DEBUG

--- a/infra/ansible/roles/trino/files/trino/etc/rules.json
+++ b/infra/ansible/roles/trino/files/trino/etc/rules.json
@@ -1,0 +1,14 @@
+{
+  "catalogs": [
+    {
+      "user": "ingestion",
+      "catalog": "isis_lakekeeper",
+      "allow": "all"
+    },
+    {
+      "user": "superset",
+      "catalog": "isis_lakekeeper",
+      "allow": "read-only"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Implements the most basic access control rules in Trino: https://trino.io/docs/current/security/file-system-access-control.html#system-level-access-control-files.

Only 2 users are currently known:

 - one that has full access (used for ingestion)
 - one that has only read access for tools such as Superset

