### PR TITLE
feat(pipelines-common): Make pyiceberg table_location_layout optional

### DIFF
--- a/pipelines/pipelines-common/src/pipelines_common/dlt_destinations/pyiceberg/configuration.py
+++ b/pipelines/pipelines-common/src/pipelines_common/dlt_destinations/pyiceberg/configuration.py
@@ -61,9 +61,7 @@ class IcebergClientConfiguration(DestinationClientDwhConfiguration):
     credentials: PyIcebergCatalogCredentials = None  # type: ignore
 
     # possible placeholders: {dataset_name}, {table_name}, {location_tag}
-    # This is deliberately prefixed with an 'r' to indicate it is not an f-string
-    # and is intended to be expanded later
-    table_location_layout: Optional[str] = r"{dataset_name}/{table_name}"
+    table_location_layout: Optional[str] = None  # type: ignore
 
     @property
     def connection_properties(self) -> Dict[str, str]:

--- a/pipelines/pipelines-common/src/pipelines_common/dlt_destinations/pyiceberg/pyiceberg.py
+++ b/pipelines/pipelines-common/src/pipelines_common/dlt_destinations/pyiceberg/pyiceberg.py
@@ -347,11 +347,15 @@ class PyIcebergClient(JobClientBase, WithStateSync):
         # same identifier are created/deleted in tight loops, e.g. in tests,
         # then the same location can produce invalid location errors.
         # The location_tag can be used to set to unique string to avoid this
-        location = f"{self.config.bucket_url}/" + self.config.table_location_layout.format(  # type: ignore
-            dataset_name=self.dataset_name,
-            table_name=table_name.rstrip("/"),
-            location_tag=uniq_id(6),
-        )
+        if self.config.table_location_layout is not None:
+            location = f"{self.config.bucket_url}/" + self.config.table_location_layout.format(  # type: ignore
+                dataset_name=self.dataset_name,
+                table_name=table_name.rstrip("/"),
+                location_tag=uniq_id(6),
+            )
+        else:
+            location = None
+
         self.iceberg_catalog.create_table(
             self.make_qualified_table_name(table_name),
             schema,

--- a/pipelines/pipelines-common/tests/docker-compose.yml
+++ b/pipelines/pipelines-common/tests/docker-compose.yml
@@ -54,8 +54,8 @@ services:
         condition: service_completed_successfully
       lakekeeper-db:
         condition: service_healthy
-      minio:
-        condition: service_healthy
+      minio_createbucket:
+        condition: service_completed_successfully
     networks:
       - lakehouse_net
     ports:
@@ -93,25 +93,48 @@ services:
       - lakehouse_net
 
   minio:
-    image: bitnami/minio:latest
+    image: quay.io/minio/minio:latest
     environment:
-      - MINIO_ROOT_USER=minio-root-user
-      - MINIO_ROOT_PASSWORD=minio-root-password
-      - MINIO_API_PORT_NUMBER=9000
-      - MINIO_CONSOLE_PORT_NUMBER=9001
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=e2e-tests-warehouse
+      MINIO_ROOT_USER: minio-root-user
+      MINIO_ROOT_PASSWORD: minio-root-password
+      MINIO_API_PORT_NUMBER: 9000
+      MINIO_CONSOLE_PORT_NUMBER: 9001
+      MINIO_SCHEME: http
+    ports:
+      - 9001:9001
+      - 9000:9000
+    command: [ "server", "/data", "--console-address", ":9001" ]
     healthcheck:
-      test: ["CMD", "mc", "ls", "local", "|", "grep", "$$MINIO_DEFAULT_BUCKETS"]
-      interval: 2s
-      timeout: 10s
-      retries: 2
-      start_period: 15s
+      test: [ "CMD", "mc", "ready", "local" ]
+      interval: 30s
+      timeout: 20s
+      retries: 3
     networks:
       - lakehouse_net
-    ports:
-      - "9000:9000"
-      - "9001:9001"
+
+  minio_createbucket:
+    depends_on:
+      minio:
+        condition: service_healthy
+    image: quay.io/minio/mc:latest
+    environment:
+      MINIO_ROOT_USER: minio-root-user
+      MINIO_ROOT_PASSWORD: minio-root-password
+      MINIO_BUCKET_NAME: e2e-tests-warehouse
+    entrypoint: |
+      /bin/sh -c "
+      /usr/bin/mc alias set minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD} \
+      if ! /usr/bin/mc ls minio/$${MINIO_BUCKET_NAME}; then \
+        echo \"Bucket '$${MINIO_BUCKET_NAME}' not found, creating...\" \
+        /usr/bin/mc mb minio/$${MINIO_BUCKET_NAME}; \
+        /usr/bin/mc anonymous set public minio/$${MINIO_BUCKET_NAME}; \
+        echo \"Bucket '$${MINIO_BUCKET_NAME}' created with public access policy\" \
+      else \
+        echo \"Found bucket '$${MINIO_BUCKET_NAME}'\" \
+      fi \
+      "
+    networks:
+      - lakehouse_net
 
   python-uv:
     profiles:

--- a/pipelines/pipelines-common/tests/unit_tests/dlt_destinations/pyiceberg/test_configuration.py
+++ b/pipelines/pipelines-common/tests/unit_tests/dlt_destinations/pyiceberg/test_configuration.py
@@ -15,7 +15,7 @@ def test_initial_iceberg_config_state_defaults_to_rest():
 
     assert default_config.bucket_url is None
     assert default_config.catalog_type == "rest"
-    assert default_config.table_location_layout == r"{dataset_name}/{table_name}"
+    assert default_config.table_location_layout is None
     assert default_config.credentials is None
     assert default_config.connection_properties == {}
 


### PR DESCRIPTION
### Summary

The catalog will create a UUID for the path components if no location is provided. This should discourage interaction with the S3 layer directly as it will not be so obvious what files belong to what table.

Aside:

The e2e tests started to fail because the Bitnami minio image no longer created the correct buckets on startup. We switch to the official minio image and create the bucket manually.