### PR TITLE
feat(ansible-docker): Support for disabling ingestion jobs

### DIFF
--- a/infra/ansible-docker/playbooks/ingestion/setup.yml
+++ b/infra/ansible-docker/playbooks/ingestion/setup.yml
@@ -123,6 +123,7 @@
     - name: Ensure daily statusdisplay ingest job exists
       ansible.builtin.cron:
         name: "Statusdisplay ingest"
+        state: "{{ ingestion_cron_state | default('present') }}"
         minute: "15"
         hour: "0"
         job: "{{ ingestion_elt_cron_scripts_dir }}/elt_task.sh pipelines/ingest/statusdisplay pipelines/modelling/isis --select '+models/facility' > {{ ingestion_elt_cron_log_dir }}/statusdisplay/elt-$(date +\\%Y\\%m\\%d_\\%H\\%M\\%S).log 2>&1"
@@ -141,7 +142,7 @@
     - name: Ensure daily Opralog ingest job exists
       ansible.builtin.cron:
         name: "Opralog ingest"
-        state: "present"
+        state: "{{ ingestion_cron_state | default('present') }}"
         minute: "10"
         hour: "2"
         job: "{{ ingestion_elt_cron_scripts_dir }}/elt_task.sh pipelines/ingest/opralogweb pipelines/modelling/isis --select '+models/accelerator' > {{ ingestion_elt_cron_log_dir }}/opralogweb/elt-$(date +\\%Y\\%m\\%d_\\%H\\%M\\%S).log 2>&1"


### PR DESCRIPTION
Allows the ingestion jobs to be disabled if necessary.

For example, the cloud came back up after an outage but we didn't want the ingestion jobs to run until the platform was confirmed to be more stable.
