### PR TITLE
feat(ansible-docker): Change superset base path

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,9 @@ operational data.
 
 ## Quick links
 
-- [ISIS Superset][isis-superset]
+Dashboards:
+
+- [Accelerator][isis-superset]
 
 ## Getting started
 
@@ -26,4 +28,4 @@ The platform consists of several components, each focused on a specific purpose.
 If you are unsure where to start then [Superset](./superset/index.md) is a good place to begin exploring.
 
 <!-- Common links -->
-[isis-superset]: https://data-accelerator.isis.cclrc.ac.uk/analytics/superset "ISIS Superset"
+[accelerator-superset]: https://analytics.isis.cclrc.ac.uk/workspace/accelerator/ "Accelerator Superset"

--- a/docs/src/superset/index.md
+++ b/docs/src/superset/index.md
@@ -1,12 +1,7 @@
 # Superset
 
 <!-- Common links -->
-[isis-superset]: https://data-accelerator.isis.cclrc.ac.uk/analytics/superset "ISIS Superset"
 [apache-superset]: https://superset.apache.org/ "Apache Superset"
-
-## Quick links
-
-- [ISIS Superset][isis-superset]
 
 ## Getting started
 
@@ -20,7 +15,7 @@ pre-configured datasets.
 
 ### Logging in
 
-When visiting [Superset][isis-superset] for the first time you will
+When visiting Superset for the first time you will
 be presented with a login screen:
 
 ![Superset login screen](../assets/images/superset/isis-superset-login-screen.png)

--- a/infra/ansible-docker/group_vars/all/superset.yml
+++ b/infra/ansible-docker/group_vars/all/superset.yml
@@ -7,11 +7,11 @@ superset_metadb_port: 5432
 superset_container_network: superset
 superset_http_port: 8088
 
-# latest
-# superset_build_git_ref: 465a696c53c693e7448b119e020ea8cc59d3a734
+# Pinned to the merge reference that contains our modifications to allow Superset on
+# prefix path.
 superset_build_git_ref: 901412e9a8346153c26949b4e8d5085856cc9bf2
 
-superset_app_root: "/analytics/superset"
+superset_app_root: "/workspace/accelerator"
 superset_flask_debug: false
 superset_env_name: production
 

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/docs.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/docs.yml.j2
@@ -3,14 +3,14 @@ http:
     # TLS
     docs-no-trailing-slash:
       entryPoints: web_tls
-      rule: PathRegexp(`^/docs$`)
+      rule: Host(`{{ top_level_domain }}`) && Host(`{{ top_level_domain }}`) && PathRegexp(`^/docs$`)
       middlewares:
         - docs-redirect-to-index
       service: docs
       tls: {}
     docs:
       entryPoints: web_tls
-      rule: PathPrefix(`/docs`)
+      rule: Host(`{{ top_level_domain }}`) && Host(`{{ top_level_domain }}`) && PathPrefix(`/docs`)
       service: docs
       middlewares:
         - docs-strip-prefix

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/jupyterhub.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/jupyterhub.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     jupyterhub:
       entryPoints: web_tls
-      rule: PathPrefix(`{{ jupyterhub_base_path }}`)
+      rule: Host(`{{ top_level_domain }}`) && PathPrefix(`{{ jupyterhub_base_path }}`)
       service: jupyterhub
       tls: {}
 

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/keycloak.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/keycloak.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     keycloak:
       entryPoints: web_tls
-      rule: PathPrefix(`{{ keycloak_base_path }}`)
+      rule: Host(`{{ top_level_domain }}`) && PathPrefix(`{{ keycloak_base_path }}`)
       service: keycloak
       middlewares:
         - keycloak-strip-prefix

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/lakekeeper.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/lakekeeper.yml.j2
@@ -2,7 +2,7 @@ http:
   routers:
     lakekeeper_tls:
       entryPoints: web_tls
-      rule: PathPrefix(`{{ lakekeeper_base_path }}`)
+      rule: Host(`{{ top_level_domain }}`) && PathPrefix(`{{ lakekeeper_base_path }}`)
       service: lakekeeper
 {% if lakekeeper_base_path != '/' %}
       middlewares:

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/minio.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/minio.yml.j2
@@ -4,7 +4,7 @@ http:
     # TLS
     minio:
       entryPoints: minio_tls
-      rule:  PathPrefix(`/`)
+      rule: Host(`{{ top_level_domain }}`) &&  PathPrefix(`/`)
       service: minio
       tls: {}
 

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/root.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/root.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     root:
       entryPoints: web_tls
-      rule: PathRegexp(`^/?$`)
+      rule: Host(`{{ top_level_domain }}`) && PathRegexp(`^/?$`)
       middlewares:
         - root-redirect-to-docs
       service: docs

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/spark.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/spark.yml.j2
@@ -16,7 +16,7 @@ http:
   routers:
     sparkcontrollerui:
       entryPoints: sparkcontrollerui_tls
-      rule:  PathPrefix(`/`)
+      rule: Host(`{{ top_level_domain }}`) &&  PathPrefix(`/`)
       service: sparkcontrollerui
       tls: {}
 

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/superset.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/superset.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     superset:
       entryPoints: web_tls
-      rule: PathPrefix(`{{ superset_app_root }}`)
+      rule: Host(`{{ top_level_domain }}`) && PathPrefix(`{{ superset_app_root }}`)
       service: superset
       tls: {}
 

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/traefik.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/traefik.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     traefik:
       entryPoints: web_tls
-      rule: PathPrefix(`/traefik`) || HeaderRegexp(`Referer`, `/traefik`)
+      rule: Host(`{{ top_level_domain }}`) && (PathPrefix(`/traefik`) || HeaderRegexp(`Referer`, `/traefik`))
       service: api@internal
       middlewares:
         - traefik-strip-prefix

--- a/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/trino.yml.j2
+++ b/infra/ansible-docker/roles/traefik/templates/etc/traefik/dynamic/trino.yml.j2
@@ -3,7 +3,7 @@ http:
     # TLS
     trino:
       entryPoints: trino_tls
-      rule: PathPrefix(`/`)
+      rule: Host(`{{ top_level_domain }}`) && PathPrefix(`/`)
       service: trino
       tls: {}
 


### PR DESCRIPTION
Uses new base path `/workspace/accelerator`.

Allows space for other superset instances that can sit at the same `/workpace` level in the URL hierararchy.

Fixes #86 
