### PR TITLE
fix(pipelines): Run dbt deps to install dbt dependencies

### DIFF
--- a/infra/ansible-docker/playbooks/ingestion/templates/cron/elt_task.sh.j2
+++ b/infra/ansible-docker/playbooks/ingestion/templates/cron/elt_task.sh.j2
@@ -51,6 +51,6 @@ if [ -n "$dbt_project_dir" ]; then
   uv venv
   uv pip install -r requirements/$REQUIREMENTS_TXT
   export SPARK_CONF_DIR
-  uv run \
-    dbt run $*
+  uv run dbt deps
+  uv run dbt run $*
 fi


### PR DESCRIPTION
## Summary

#110 added dbt dependencies but the cron script was not configured to install them and dbt errors our in this case (even if the dependency is not used).
