### PR TITLE
fix(pipelines/ingest) - Allow dlt.resource or dlt.source decorated functions in cli_main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ clouds.yaml
 .env
 .venv/
 **/dbt.log
+# ignore secrets, virtual environments and typical python compilation artifacts
+secrets.toml

--- a/pipelines/ingest/opralogweb/extract_and_load.py
+++ b/pipelines/ingest/opralogweb/extract_and_load.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     cli_utils.cli_main(
         pipeline_name="opralogweb",
         default_destination="pipelines_common.dlt_destinations.pyiceberg",
-        data_generator=opralogwebdb(),
+        data_generator=opralogwebdb,
         dataset_name_suffix="opralogweb",
         default_write_disposition="append",
     )

--- a/pipelines/pipelines-common/src/pipelines_common/cli.py
+++ b/pipelines/pipelines-common/src/pipelines_common/cli.py
@@ -9,6 +9,7 @@ import dlt
 from dlt.common.destination.reference import TDestinationReferenceArg
 from dlt.common.typing import TLoaderFileFormat
 from dlt.common.schema.typing import TWriteDisposition
+from dlt.extract.reference import SourceFactory
 from dlt.pipeline.progress import TCollectorArg, _NULL_COLLECTOR as NULL_COLLECTOR
 import humanize
 
@@ -104,8 +105,12 @@ def cli_main(
     LOGGER.info(f"-- Starting pipeline={pipeline.pipeline_name} --")
     LOGGER.info("Dropping pending packages to ensure a clean new load")
     pipeline.drop_pending_packages()
+    if isinstance(data_generator, SourceFactory):
+        data = data_generator()
+    else:
+        data = data_generator
     pipeline.run(
-        data_generator,
+        data,
         loader_file_format=args.loader_file_format,
         write_disposition=args.write_disposition,
     )


### PR DESCRIPTION
### Summary

A pipeline object is required in order for the dlt configuration framework to use the pipeline name to further disambiguate keys. Without a pipeline the config framework stops at the left most `sources` key.

In `cli_main` we check if the `data_generator` needs calling before being passed to `pipeline.run`.
