### PR TITLE
chore(infra): Rename isis to local_warehouse in dev setup

### DIFF
--- a/infra/local/README.md
+++ b/infra/local/README.md
@@ -24,11 +24,11 @@ Create and add the following to `$HOME/.dlt/secrets.toml`:
 
 ```sh
 [destination.pyiceberg]
-bucket_url = "s3://local-lakehouse-isis"
+bucket_url = "s3://local-lakehouse"
 
 [destination.pyiceberg.credentials]
 uri = "http://analytics.localhost:58080/internal/iceberg-rest/catalog"
-warehouse = "isis"
+warehouse = "local_lakehouse"
 ```
 
 **Do not put production secrets here.**

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -120,7 +120,7 @@ services:
     environment:
       MINIO_ROOT_USER: adpuser
       MINIO_ROOT_PASSWORD: adppassword
-      MINIO_BUCKET_NAME: local-lakehouse-isis
+      MINIO_BUCKET_NAME: local-lakehouse
     entrypoint: |
       /bin/sh -c "
       /usr/bin/mc alias set minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD} \
@@ -201,6 +201,7 @@ services:
   # Trino query engine
   #########################################################
   trino:
+    container_name: local-lakehouse-trino
     image: *trino-image
     volumes:
       - "./trino/etc:/etc/trino:ro"

--- a/infra/local/lakekeeper/bootstrap-warehouse.json
+++ b/infra/local/lakekeeper/bootstrap-warehouse.json
@@ -1,5 +1,5 @@
 {
-  "warehouse-name": "isis",
+  "warehouse-name": "local_lakehouse",
   "project-id": "00000000-0000-0000-0000-000000000000",
   "storage-credential": {
     "type": "s3",
@@ -9,7 +9,7 @@
   },
   "storage-profile": {
     "type": "s3",
-    "bucket": "local-lakehouse-isis",
+    "bucket": "local-lakehouse",
     "key-prefix": "",
     "endpoint": "http://analytics.localhost:59000",
     "region": "local-01",

--- a/infra/local/superset/docker/docker-init.sh
+++ b/infra/local/superset/docker/docker-init.sh
@@ -61,6 +61,6 @@ echo_step "3" "Complete" "Setting up roles and perms"
 # Create a database connection
 echo_step "4" "Starting" "Setting up Iceberg catalog connection"
 superset set-database-uri \
-  --database_name isis \
-  --uri "trino://trino@trino:8080/isis"
+  --database_name local_lakehouse \
+  --uri "trino://trino@trino:8080/local_lakehouse"
 echo_step "4" "Complete" "Setting up data source database connection"

--- a/infra/local/trino/etc/catalog/local_lakehouse.properties
+++ b/infra/local/trino/etc/catalog/local_lakehouse.properties
@@ -1,6 +1,6 @@
 connector.name=iceberg
 iceberg.catalog.type=rest
-iceberg.rest-catalog.warehouse=isis
+iceberg.rest-catalog.warehouse=local_lakehouse
 iceberg.rest-catalog.uri=http://lakekeeper:8181/catalog
 iceberg.rest-catalog.vended-credentials-enabled=false
 


### PR DESCRIPTION
### Summary

The local/dev catalog used to be called 'isis' but this could be confused easily with the production one. Rename it to have local in the name.

 *There is no associated issue.*
