### PR TITLE
fix(warehouses/accelreator): Calculate MTBF in mins

### DIFF
--- a/warehouses/accelerator/transform/accelerator/models/operations/mean_time_between_failure.sql
+++ b/warehouses/accelerator/transform/accelerator/models/operations/mean_time_between_failure.sql
@@ -50,7 +50,7 @@ mean_time_between_failures as (
 
     any_value(cycle_name) as cycle_name,
     equipment,
-    sum(uptime_mins)/count(fault_occurred_at)/60. as mtbf_hours
+    sum(uptime_mins)/count(fault_occurred_at) as mtbf_mins
 
   from uptime_col
   where cycle_name is not null


### PR DESCRIPTION
### Summary

Other models have columns calculated in minutes so be consistency. They can be rescaled in the BI tool if needed.

<!--- Describe the change below, including rationale and design decisions -->

<!-- alternative
 *There is no associated issue.*
-->
