### PR TITLE
fix(warehouses/accelerator): Set first uptime value to NULL for first dowtime record of cycle

### DIFF
--- a/warehouses/accelerator/transform/accelerator/models/operations/mcr_equipment_downtime_records.sql
+++ b/warehouses/accelerator/transform/accelerator/models/operations/mcr_equipment_downtime_records.sql
@@ -96,12 +96,9 @@ uptime_col as (
     fault_occurred_at,
     equipment_up_at,
     date_diff('minute',
-      lag(equipment_up_at, 1,
-          (select started_at from cycles_start_end where {{ adapter.quote('name') }} = cycle_name)
-          )
-          over
+      lag(equipment_up_at, 1, null) over
           (partition by cycle_name, equipment order by fault_occurred_at), fault_occurred_at
-    ) as uptime_mins,
+    ) as uptime_before_fault_mins,
     {{ adapter.quote('group') }},
     fault_description,
     managers_comments
@@ -121,7 +118,7 @@ equipment_category_col as (
     downtime_mins,
     fault_occurred_at,
     equipment_up_at,
-    uptime_mins,
+    uptime_before_fault_mins,
     {{ adapter.quote('group') }},
     fault_description,
     managers_comments


### PR DESCRIPTION
### Summary

It's not correct to arbitrarily take the cycle start as the first equipment up point as some equipment may be on all of the time.  Rename the `uptime_mins` to `uptime_before_fault_mins` for clarity  and set it to NULL for the first entry in a cycle.

For the MTBF calculation equipment with fewer than 3 faults will be ignored in Superset.