### PR TITLE
fix(warehouses/accelerator): Use correct column name in power_consumption model

### DIFF
--- a/warehouses/accelerator/transform/accelerator/models/operations/power_consumption.sql
+++ b/warehouses/accelerator/transform/accelerator/models/operations/power_consumption.sql
@@ -13,7 +13,7 @@ staged as (
 
   select
 
-    date_time as power_measured_at,
+    power_measured_at,
     total_isis_power_mw
 
   from {{ ref('stg_electricity_sharepoint_rdm_data') }}


### PR DESCRIPTION
### Summary

Fix column name reference in power consumption model. The source data is being updated but power consumption model kept failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how the power_measured_at timestamp is produced in power consumption data by selecting the column directly instead of aliasing another field.
  * Improves clarity and maintainability without changing reported metrics or outputs.

* **Chores**
  * Minor internal cleanup to ensure consistent column sourcing in power consumption transformations.

No user-facing behaviour or data outputs are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->