### PR TITLE
feat(infra): Introduce a variable to control dlt write disposition behaviour for elt tasks

### DIFF
--- a/infra/ansible-docker/playbooks/elt/templates/cron/elt_task.sh.j2
+++ b/infra/ansible-docker/playbooks/elt/templates/cron/elt_task.sh.j2
@@ -4,6 +4,7 @@ set -euo pipefail
 # Constants
 ELT_SECRETS=${ELT_SECRETS:?}
 ELT_GIT_REF=${ELT_GIT_REF:-main}
+ELT_WRITE_DISPOSITION=${ELT_WRITE_DISPOSITION:-}
 EXTRACT_AND_LOAD_SCRIPT=extract_and_load.py
 LOG_LEVEL=DEBUG
 ON_PIPELINE_FAILURE=log_and_continue
@@ -51,11 +52,17 @@ set -o allexport; source $ELT_SECRETS; set +o allexport
 # Extraction
 ensure_elt_sources_exist $git_url $git_clone_dir
 cd $git_clone_dir/$extract_and_load_dir
+dlt_write_disposition=
+if [ -n "$ELT_WRITE_DISPOSITION" ]; then
+  dlt_write_disposition="--write-disposition $ELT_WRITE_DISPOSITION"
+fi
 uv run \
   --reinstall \
   --script $EXTRACT_AND_LOAD_SCRIPT \
   --log-level $LOG_LEVEL \
-  --on-pipeline-step-failure $ON_PIPELINE_FAILURE
+  --on-pipeline-step-failure $ON_PIPELINE_FAILURE \
+  $dlt_write_disposition
+
 
 # Transform
 if [ -n "$dbt_project_dir" ]; then


### PR DESCRIPTION
### Summary

Previously the elt_task cron script could only use the default write disposition of the extract_and_load script. This changes introduces an optional environment variable to allow the flag to be overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ELT tasks now support configurable write disposition through environment variables, enabling control over data writing behaviour during extraction and loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->