### PR TITLE
feat(pipelines): Support setting ELT_WRITE_DISPOSITION value in Ansible playbook

### DIFF
--- a/infra/ansible-docker/playbooks/elt/elt_cron_tasks.yml
+++ b/infra/ansible-docker/playbooks/elt/elt_cron_tasks.yml
@@ -8,6 +8,7 @@
     job: >
       NO_COLOR=1 UV_NO_PROGRESS=1
       ELT_SECRETS={{ elt_secrets_root_dir }}/{{ warehouse.name }}/envvars
+      ELT_WRITE_DISPOSITION={{ source.write_disposition | default("") }}
       {{ elt_cron_root_dir }}/elt_task.sh
       https://github.com/{{ warehouse.github_org }}/{{ warehouse.github_repo }}.git
       {{ elt_git_clone_dir }}/{{ warehouse.github_org }}/{{ warehouse.github_repo }}

--- a/infra/ansible-docker/playbooks/elt/group_vars/elt.yml
+++ b/infra/ansible-docker/playbooks/elt/group_vars/elt.yml
@@ -29,6 +29,7 @@ elt_warehouses:
         hour: 2
         minute: 11
         dbt_args: "--select '+models/operations' --exclude '+models/operations/power_consumption.sql'"
+        write_disposition: "replace"
       - name: electricity_sharepoint
         hour: "*"
         minute: 5


### PR DESCRIPTION
### Summary

The Ansible playbook can now set the mode for write_disposition in the ELT cron jobs. For now Opralog is set to replace to ensure everything is fresh until #138 is implemented.

Refs #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated data warehouse configuration to support write disposition settings with replace mode enabled for improved data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->