### PR TITLE
chore(pipelines): Rename Opralog user_entries to entries to match source

### DIFF
--- a/warehouses/accelerator/extract_load/opralogweb/.dlt/config.toml
+++ b/warehouses/accelerator/extract_load/opralogweb/.dlt/config.toml
@@ -8,9 +8,6 @@ schema = "dbo"
 
 [[sources.sql_database.tables]]
 name = "Entries"
-# Spark seems to have an issue with seeing a table named 'entries' regardless of the namespace it is in
-# so we rename it
-destination_name = "user_entries"
 incremental_id = "EntryId"
 html_to_markdown_columns = ["AdditionalComment"]
 

--- a/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/_opralogweb__sources.yml
+++ b/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/_opralogweb__sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: src_opralogweb
     tables:
-      - name: user_entries
+      - name: entries
       - name: chapter_entry
       - name: logbook_chapter
       - name: logbooks

--- a/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__entries.sql
+++ b/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__entries.sql
@@ -2,7 +2,7 @@ with
 
 source as (
 
-  select * from {{ source('src_opralogweb', 'user_entries') }}
+  select * from {{ source('src_opralogweb', 'entries') }}
 
 ),
 

--- a/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__entries.yml
+++ b/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__entries.yml
@@ -1,0 +1,8 @@
+models:
+  - name: base_opralogweb__entries
+    description: >
+      Opralogweb "entries" table with basic cleaning.
+    columns:
+      - name: entry_id
+        tests:
+          - not_null

--- a/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__user_entries.yml
+++ b/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/base/base_opralogweb__user_entries.yml
@@ -1,9 +1,0 @@
-models:
-  - name: base_opralogweb__user_entries
-    description: >
-      Opralogweb "entries" table with basic cleaning. Table has been renamed from "entries"
-      due to an expected clash with a reserved internal name in Iceberg.
-    columns:
-      - name: entry_id
-        tests:
-          - not_null

--- a/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/stg_opralogweb__mcr_equipment_downtime.sql
+++ b/warehouses/accelerator/transform/accelerator/models/staging/opralogweb/stg_opralogweb__mcr_equipment_downtime.sql
@@ -3,7 +3,7 @@
 
 with
 
-staging_entries as ( select * from {{ ref('base_opralogweb__user_entries') }} ),
+staging_entries as ( select * from {{ ref('base_opralogweb__entries') }} ),
 
 staging_chapter_entry as ( select * from {{ ref('base_opralogweb__chapter_entry') }} ),
 


### PR DESCRIPTION
### Summary

No longer using the tool that prevented using the original name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Opralogweb entries table naming and removed associated configuration workarounds from staging models.
  * Simplified source definitions by removing unused table entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->