### PR TITLE
feat(infra): Publish Superset docker image on pushes to main

### DIFF
--- a/.github/workflows/docker-superset.yml
+++ b/.github/workflows/docker-superset.yml
@@ -20,7 +20,7 @@ env:
   REGISTRY: ghcr.io
   ORG_NAME: isisneutronmuon
   IMAGE_NAME: analytics-data-platform-superset
-  PUBLISH: ${{ github.ref == 'refs/heads/main' && true || false }}
+  PUBLISH: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release management by restricting Docker image publishing and artifact attestation to the main branch only, ensuring controlled and stable deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->