### PR TITLE
feat(pre-commit): Drop requirement for docker in pre-commit hooks

### DIFF
--- a/.github/workflows/ci-static.yml
+++ b/.github/workflows/ci-static.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   staticcheck:
     name: static checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       # Run the formatter.
       - id: ruff-format
         files: elt-common
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.20.0
     hooks:
-      - id: markdownlint-cli2-docker
+      - id: markdownlint-cli2
         exclude: '^(?:\.github|docs)(?:/|$)'


### PR DESCRIPTION
### Summary

Requiring docker is quite heavy for pre-commit. Move to non-docker base solutions. 

- Move shellcheck to Python-based version.
- markdownlint-cli2 now needs node but is lighter weight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for static analysis checks with alternative Ubuntu infrastructure
  * Updated shellcheck pre-commit hook with new repository source and revised version
  * Migrated markdownlint pre-commit hook from Docker-based implementation to standard variant

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->