### PR TITLE
chore(ansible) Rename the landing bucket for iceberg tables

### DIFF
--- a/infra/ansible/group_vars/all/all.yml
+++ b/infra/ansible/group_vars/all/all.yml
@@ -32,6 +32,7 @@ keycloak_realm:
 keycloak_realm_url: "{{ keycloak_url }}/realms/{{ keycloak_realm.name }}"
 
 lakekeeper_base_path: /iceberg
+lakekeeper_bucket_prefix: isis-adp-warehouse-
 lakekeeper_http_port: 8181
 
 pip_install_packages:
@@ -53,8 +54,8 @@ lakekeeper_catalog:
   warehouses:
     facility_ops_landing:
       storage:
-        bucket_name: "{{ lakekeeper_bucket_prefix }}facility-ops-landing"
-        key_prefix: iceberg
+        bucket_name: "{{ lakekeeper_bucket_prefix }}facility-ops-landing-iceberg"
+        key_prefix: ""
       elt_jobs:
         github_org: ISISNeutronMuon
         github_repo: analytics-data-platform

--- a/infra/ansible/inventories/dev/group_vars/all/all.yml
+++ b/infra/ansible/inventories/dev/group_vars/all/all.yml
@@ -9,5 +9,3 @@ s3_endpoint: "https://{{ top_level_domain }}:{{ minio_api_port }}"
 s3_region: minio # not used but can be required by apis
 s3_access_key_id: "{{ vault_minio_root_user }}"
 s3_access_secret: "{{ vault_minio_root_passwd }}"
-
-lakekeeper_bucket_prefix: warehouse-

--- a/infra/ansible/inventories/qa/group_vars/all/all.yml
+++ b/infra/ansible/inventories/qa/group_vars/all/all.yml
@@ -5,5 +5,3 @@ s3_endpoint: https://s3.echo.stfc.ac.uk
 s3_region: echo-01 # not used but can be required by apis
 s3_access_key_id: "{{ vault_echo_access_id }}"
 s3_access_secret: "{{ vault_echo_access_secret }}"
-
-lakekeeper_bucket_prefix: isis-analytics-data-platform-warehouse-

--- a/infra/ansible/roles/elt/templates/cron/elt_task.sh.j2
+++ b/infra/ansible/roles/elt/templates/cron/elt_task.sh.j2
@@ -17,6 +17,7 @@ function ensure_elt_sources_exist() {
     pushd $git_clone_dir
     git clean -d -x --force
     git reset --hard
+    git fetch --prune
     git checkout "$ELT_GIT_REF"
     git pull
     popd


### PR DESCRIPTION
### Summary

Clarify that the landing bucket for data ingested directly to iceberg tables only contains iceberg data. It removes
the key prefix and names the bucket accordingly with iceberg in the name.

The motivation for this change is the likelihood of other landing buckets existing for raw data in other formats. There is now a clear naming pattern for suffixes of `-landing-{descriptor}`.