### PR TITLE
fix(warehouses): Catch nan strings that look like floats to Python.

### DIFF
--- a/.github/workflows/rest-catalog-tests.yml
+++ b/.github/workflows/rest-catalog-tests.yml
@@ -7,15 +7,15 @@ on:
       - ".github/workflows/rest-catalog-tests.yml"
       - "infra/ansible/roles/lakekeeper/files/bootstrap-warehouse.py"
       - "elt-common/**"
-      - "warehouses/facility_ops_landing/extract_load/opralogweb/**"
+      - "warehouses/facility_ops_landing/ingest/accelerator/opralogweb/**"
       - "warehouses/facility_ops/transform/**"
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
     paths:
       - ".github/workflows/rest-catalog-tests.yml"
       - "infra/ansible/roles/lakekeeper/files/bootstrap-warehouse.py"
       - "elt-common/**"
-      - "warehouses/facility_ops_landing/extract_load/opralogweb/**"
+      - "warehouses/facility_ops_landing/ingest/accelerator/opralogweb/**"
       - "warehouses/facility_ops/transform/**"
 
 concurrency:

--- a/warehouses/facility_ops_landing/ingest/accelerator/opralogweb/opralogweb.py
+++ b/warehouses/facility_ops_landing/ingest/accelerator/opralogweb/opralogweb.py
@@ -114,7 +114,7 @@ def additional_comment_to_markdown(table: pa.Table) -> pa.Table:
         pa.array(
             table[column_name]
             .to_pandas()
-            .apply(lambda x: x if x is None else html2text(x))
+            .apply(lambda x: html2text(x) if isinstance(x, str) else x)
         ),
     )
 


### PR DESCRIPTION
### Summary

An error:

```sh
File "/home/ubuntu/var/git/warehouses/facility_ops_landing/ingest/accelerator/opralogweb/opralogweb.py", line 112, in to_text
    return html2text(x) if x is not None else x
           ~~~~~~~~~^^^
  File "/home/ubuntu/.cache/uv/environments-v2/opralogweb-60e3316910e64632/lib/python3.13/site-packages/html2text/__init__.py", line 1028, in html2text
    return h.handle(html)
           ~~~~~~~~^^^^^^
  File "/home/ubuntu/.cache/uv/environments-v2/opralogweb-60e3316910e64632/lib/python3.13/site-packages/html2text/__init__.py", line 149, in handle
    self.feed(data)
    ~~~~~~~~~^^^^^^
  File "/home/ubuntu/.cache/uv/environments-v2/opralogweb-60e3316910e64632/lib/python3.13/site-packages/html2text/__init__.py", line 144, in feed
    data = data.replace("</' + 'script>", "</ignore>")
           ^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'replace'
```

appeared in the Opralogweb extract logs. It came from a text containing 'nan' that had been converted to a Python float and html2text failed on it. This adds protection to only process strings.

Note that this was spotted by a user as we don't have the required visibility of the ELT pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of additional comment conversion during markdown formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->