### PR TITLE
feat(elt-common): Watermark (de)serializiation

### DIFF
--- a/elt-common/src/elt_common/extract.py
+++ b/elt-common/src/elt_common/extract.py
@@ -13,11 +13,11 @@ class Watermark:
     column: str
     value: str | int | float
 
-    def serialize(self):
+    def serialize(self) -> str:
         return json.dumps({"column": self.column, "value": self.value})
 
     @staticmethod
-    def deserialize(watermark_str: str):
+    def deserialize(watermark_str: str) -> "Watermark":
         as_json = json.loads(watermark_str)
         if "column" not in as_json or as_json["column"] is None:
             raise ValueError(

--- a/elt-common/src/elt_common/extract.py
+++ b/elt-common/src/elt_common/extract.py
@@ -1,5 +1,6 @@
 import dataclasses as dc
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, get_args
+import json
+from typing import TYPE_CHECKING, Callable, Iterator, Optional, get_args
 
 from elt_common.typing import WriteMode
 
@@ -10,7 +11,34 @@ if TYPE_CHECKING:
 @dc.dataclass(frozen=True)
 class Watermark:
     column: str
-    value: Any
+    value: str | int | float
+
+    def serialize(self):
+        return json.dumps({"column": self.column, "value": self.value})
+
+    @staticmethod
+    def deserialize(watermark_str: str):
+        as_json = json.loads(watermark_str)
+        if "column" not in as_json or as_json["column"] is None:
+            raise ValueError(
+                f"Couldn't deserialize {watermark_str} as a watermark, 'column' was missing"
+            )
+        elif "value" not in as_json or as_json["value"] is None:
+            raise ValueError(
+                f"Couldn't deserialize {watermark_str} as a watermark, 'value' was missing"
+            )
+
+        column = as_json["column"]
+        if type(column) is not str:
+            raise ValueError(f"Watermark 'column' must be a string, '{column}' is not valid")
+
+        value = as_json["value"]
+        if type(value) not in (str, int, float):
+            raise ValueError(
+                f"Watermark 'value' must be a string or number, '{value}' is not valid"
+            )
+
+        return Watermark(column=column, value=value)
 
 
 @dc.dataclass(frozen=True, kw_only=True)

--- a/elt-common/src/elt_common/extract.py
+++ b/elt-common/src/elt_common/extract.py
@@ -1,7 +1,7 @@
 import dataclasses as dc
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Optional, get_args
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, get_args
 
-WriteMode = Literal["append", "merge", "replace"]
+from elt_common.typing import WriteMode
 
 if TYPE_CHECKING:
     import pyarrow as pa

--- a/elt-common/tests/unit_tests/test_extract.py
+++ b/elt-common/tests/unit_tests/test_extract.py
@@ -1,0 +1,36 @@
+import pytest
+
+from elt_common.extract import Watermark
+
+
+@pytest.mark.parametrize(
+    "serialized,expected_error_message",
+    [
+        ("", "Expecting value"),
+        ("{}", "'column' was missing"),
+        ('{"column": "no_value"}', "'value' was missing"),
+        ('{"value": "no_column"}', "'column' was missing"),
+        ("{'column': 'single_quotes', 'value': 123}", "double quotes"),
+        ('{"column": 123, "value": "non_string_column"}', "Watermark 'column' must be a string"),
+        ('{"column": "null_value", "value": null}', "'value' was missing"),
+        ('{"column": null, "value": "null_column"}', "'column' was missing"),
+        ('{"column": "bool_value", "value": true}', "'value' must be a string or number"),
+        ('{"column": "array_value", "value": [1]}', "'value' must be a string or number"),
+        ('{"column": "object_value", "value": {"a": 123}}', "'value' must be a string or number"),
+    ],
+)
+def test_deserialize_watermark_bad_values_value_error(serialized, expected_error_message):
+    with pytest.raises(ValueError, match=expected_error_message):
+        Watermark.deserialize(serialized)
+
+
+@pytest.mark.parametrize(
+    "serialized,expected",
+    [
+        ('{"column": "string_value", "value": "123"}', Watermark("string_value", "123")),
+        ('{"column": "int_value", "value": 123}', Watermark("int_value", 123)),
+        ('{"column": "float_value", "value": 123.123}', Watermark("float_value", 123.123)),
+    ],
+)
+def test_deserialize_watermark_good_values(serialized, expected):
+    assert Watermark.deserialize(serialized) == expected


### PR DESCRIPTION
ref #321

Adds functionality for (de)serializing watermarks from/to JSON, to be read/written from/to iceberg properties.

Compared with `elt-command-without-dlt`, I've removed the abstraction of `WatermarkSerialization` to simplify the code a little. There was only a single implementation, and I don't _think_ we'll need others(?), so seemed like a case of YAGNI.

Also combines `WriteMode` definitions as [mentioned here](https://github.com/ISISNeutronMuon/analytics-data-platform/pull/339#issue-4623242437).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watermark data can now be serialised and deserialised as JSON
  * Enhanced type validation for watermark values (string, integer, or float)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->